### PR TITLE
allow to disable the F1 and F2 key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ In normal mode, the **`F2`** key opens in a new tab the example `csd` for the op
 
 This only works if the global variable `g:csound_manual` is defined and points to a local copy of the html manual.
 
+### disable manual key bindings
+
+If you want to disable the **`F1`** and **`F2`** key bindings you can do so by setting the
+`g:csound_enable_manual_keys` variable to `0` in your Vim configuration file.
+
+	let g:csound_enable_manual_keys = 0
+
 ## Contributing
 
 You can contribute to the development of this plugin by reporting bugs or missing elements, and by suggesting improvements and new functionalities. 

--- a/plugin/csound.vim
+++ b/plugin/csound.vim
@@ -3,7 +3,7 @@
 " Language:	csound	
 " Maintainer:	luis jure <lj@eumus.edu.uy>
 " License:	MIT
-" Last Change:	2020-02-19
+" Last Change:	2024-01-18
 
 " configure dictionary for autocompletion
 au FileType csound execute 'setlocal dict=<sfile>:p:h:h/words/csound.txt'
@@ -69,5 +69,11 @@ function! OpenExample()
   endif
 endfunction
 
-noremap <F1> :call OpenManual()<CR><CR>
-noremap <F2> :call OpenExample()<CR>
+" enable the manual key mappings by default
+if !exists('g:csound_enable_manual_keys')
+	let g:csound_enable_manual_keys = 1
+endif
+if g:csound_enable_manual_keys
+	noremap <F1> :call OpenManual()<CR><CR>
+	noremap <F2> :call OpenExample()<CR>
+endif


### PR DESCRIPTION
Hi, I was missing a way to disable the bindings because they conflicted with other config, so I add a config option for that. Please let me know if you prefer to change something.